### PR TITLE
Try to fix Carthage build issue

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "hamcrest/OCHamcrest" >= 5.1.0
+github "hamcrest/OCHamcrest" ~> 5.1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "hamcrest/OCHamcrest"
+github "hamcrest/OCHamcrest" >= 5.1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "hamcrest/OCHamcrest" ~> 5.1
+github "hamcrest/OCHamcrest"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "hamcrest/OCHamcrest" "v5.1.0"
+github "hamcrest/OCHamcrest" "v5.2.0"

--- a/Source/OCMockito.xcodeproj/project.pbxproj
+++ b/Source/OCMockito.xcodeproj/project.pbxproj
@@ -2714,7 +2714,8 @@
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SRCROOT)\"",
-					"\"$(SRCROOT)/../Frameworks/OCHamcrest-5.1.0\"",
+					"\"$(SRCROOT)/../Frameworks/\"",
+					"\"$(SRCROOT)/../Carthage/\"/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
@@ -2740,7 +2741,8 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SRCROOT)\"",
-					"\"$(SRCROOT)/../Frameworks/OCHamcrest-5.1.0\"",
+					"\"$(SRCROOT)/../Frameworks/\"",
+					"\"$(SRCROOT)/../Carthage/\"/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;


### PR DESCRIPTION
When trying to build OCMockito, I get the following error: 
`ld: warning: directory not found for option '-F/<removed>/Carthage/Checkouts/OCMockito/Source/../Frameworks/OCHamcrest-5.1.0'`
